### PR TITLE
 Added an example on how to use an SSL Connection with RedisAI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,13 @@ jobs:
           name: Copy RedisAI
           command: |
             docker run --rm --entrypoint cat redisai/redisai:edge  /usr/lib/redis/modules/redisai.so > redisai.so
+            docker run -v ./redisai.so:/data/redisai.so \
+                       -v ./redis/tests/tls/:/data \
+                       -p 6379:6379 redis redis-server --tls-port 6379 --port 0  \
+                       --tls-cert-file /data/redis.crt  \
+                       --tls-key-file /data/redis.key  \
+                       --tls-ca-cert-file /data/ca.crt \
+                       --tls-auth-clients no  --loadmodule /data/redisai.so
 
   build-edge: # test with redisai:edge
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Run RedisAI with tls support
           command: |
-            docker run -v $(pwd)/redisai.so:/data/redisai.so \
+            docker run -d -v $(pwd)/redisai.so:/data/redisai.so \
                        -v $(pwd)/redis/tests/tls/:/data \
                        -p 6379:6379 redis redis-server --tls-port 6379 --port 0  \
                        --tls-cert-file /data/redis.crt  \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - run:
           name: Generate a root CA and a server certificate using redis helpers
           command: |
+            ls
             git clone git://github.com/antirez/redis.git --branch 6.0.1
             cd redis
             ./utils/gen-test-certs.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,13 @@ jobs:
   build-tls:
     machine:
       enabled: true
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
       - run:
           name: Setting GOPATH
           command: |
+            go version
             go env -w GOPATH=$HOME/go
       - run:
           name: Generate a root CA and a server certificate using redis helpers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Redis with TLS support
+          name: Generate a root CA and a server certificate using redis helpers
           command: |
             git clone git://github.com/antirez/redis.git --branch 6.0.1
             cd redis
@@ -20,6 +20,10 @@ jobs:
           name: Copy RedisAI
           command: |
             docker run --rm --entrypoint cat redisai/redisai:edge  /usr/lib/redis/modules/redisai.so > redisai.so
+            chmod 755 redisai.so
+      - run:
+          name: Run RedisAI with tls support
+          command: |
             docker run -v ./redisai.so:/data/redisai.so \
                        -v ./redis/tests/tls/:/data \
                        -p 6379:6379 redis redis-server --tls-port 6379 --port 0  \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,12 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Setting GOPATH
+          command: |
+            go env -w GOPATH=$HOME/go
+      - run:
           name: Generate a root CA and a server certificate using redis helpers
           command: |
-            ls
             git clone git://github.com/antirez/redis.git --branch 6.0.1
             cd redis
             ./utils/gen-test-certs.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
       - run:
           name: Run RedisAI with tls support
           command: |
-            docker run -v redisai.so:/data/redisai.so \
-                       -v redis/tests/tls/:/data \
+            docker run -v $(pwd)/redisai.so:/data/redisai.so \
+                       -v $(pwd)/redis/tests/tls/:/data \
                        -p 6379:6379 redis redis-server --tls-port 6379 --port 0  \
                        --tls-cert-file /data/redis.crt  \
                        --tls-key-file /data/redis.key  \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,12 @@ jobs:
           command: |
             git clone git://github.com/antirez/redis.git --branch 6.0.1
             cd redis
-            make BUILD_TLS=yes
             ./utils/gen-test-certs.sh
-            ./src/redis-server --version
             cd ..
+      - run:
+          name: Copy RedisAI
+          command: |
+            docker run --rm --entrypoint cat redisai/redisai:edge  /usr/lib/redis/modules/redisai.so > redisai.so
 
   build-edge: # test with redisai:edge
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,22 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
+  build-tls:
+    machine:
+      enabled: true
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Install Redis with TLS support
+          command: |
+            git clone git://github.com/antirez/redis.git --branch 6.0.1
+            cd redis
+            make BUILD_TLS=yes
+            ./utils/gen-test-certs.sh
+            ./src/redis-server --version
+            cd ..
+
   build-edge: # test with redisai:edge
     docker:
       - image: circleci/golang:1.13
@@ -20,6 +36,7 @@ workflows:
   commit:
     jobs:
       - build-edge
+      - build-tls
   nightly:
     triggers:
       - schedule:
@@ -30,3 +47,4 @@ workflows:
                 - master
     jobs:
       - build-edge
+      - build-tls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs:
       - run:
           name: Run RedisAI with tls support
           command: |
-            docker run -v ./redisai.so:/data/redisai.so \
-                       -v ./redis/tests/tls/:/data \
+            docker run -v redisai.so:/data/redisai.so \
+                       -v redis/tests/tls/:/data \
                        -p 6379:6379 redis redis-server --tls-port 6379 --port 0  \
                        --tls-cert-file /data/redis.crt  \
                        --tls-key-file /data/redis.key  \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,12 @@ jobs:
                        --tls-key-file /data/redis.key  \
                        --tls-ca-cert-file /data/ca.crt \
                        --tls-auth-clients no  --loadmodule /data/redisai.so
+      - run:
+          name: Run Examples
+          command: |
+            make examples TLS_CERT=redis/tests/tls/redis.crt \
+                          TLS_KEY=redis/tests/tls/redis.key \
+                          TLS_CACERT=redis/tests/tls/ca.crt
 
   build-edge: # test with redisai:edge
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ coverage.txt
 
 # Examples
 examples/redisai_tls_client/redisai_tls_client
+redisai_pipelined_client
 examples/redisai_simple_client/redisai_simple_client
+redisai_simple_client
 examples/redisai_pipelined_client/redisai_pipelined_client
+redisai_tls_client

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 
 coverage.txt
 
+# Examples
+examples/redisai_tls_client/redisai_tls_client
+examples/redisai_simple_client/redisai_simple_client
+examples/redisai_pipelined_client/redisai_pipelined_client

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ get:
 TLS_CERT ?= redis.crt
 TLS_KEY ?= redis.key
 TLS_CACERT ?= ca.crt
+REDISAI_TEST_HOST ?= 127.0.0.1:6379
 
 examples: get
 	$(GOBUILD) ./examples/redisai_pipelined_client/.
@@ -23,7 +24,8 @@ examples: get
 	$(GOBUILD) ./examples/redisai_tls_client/.
 	./redisai_tls_client --tls-cert-file $(TLS_CERT) \
 						 --tls-key-file $(TLS_KEY) \
-						 --tls-ca-cert-file $(TLS_CACERT)
+						 --tls-ca-cert-file $(TLS_CACERT) \
+						 --host $(REDISAI_TEST_HOST)
 
 test: get
 	$(GOTEST) -race -covermode=atomic ./...

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOGET=$(GOCMD) get
 GOMOD=$(GOCMD) mod
 
 .PHONY: all test coverage
-all: test coverage
+all: test coverage examples
 
 get:
 	$(GOGET) -t -v ./redisai/...
@@ -19,6 +19,8 @@ TLS_CACERT ?= ca.crt
 REDISAI_TEST_HOST ?= 127.0.0.1:6379
 
 examples: get
+	@echo " "
+	@echo "Building the examples..."
 	$(GOBUILD) ./examples/redisai_pipelined_client/.
 	$(GOBUILD) ./examples/redisai_simple_client/.
 	$(GOBUILD) ./examples/redisai_tls_client/.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,18 @@ all: test coverage
 get:
 	$(GOGET) -t -v ./...
 
+TLS_CERT ?= redis.crt
+TLS_KEY ?= redis.key
+TLS_CACERT ?= ca.crt
+
+examples: get
+	$(GOBUILD) ./examples/redisai_pipelined_client/.
+	$(GOBUILD) ./examples/redisai_simple_client/.
+	$(GOBUILD) ./examples/redisai_tls_client/.
+	./redisai_tls_client --tls-cert-file $(TLS_CERT) \
+						 --tls-key-file $(TLS_KEY) \
+						 --tls-ca-cert-file $(TLS_CACERT)
+
 test: get
 	$(GOTEST) -race -covermode=atomic ./...
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOMOD=$(GOCMD) mod
 all: test coverage
 
 get:
-	$(GOGET) -t -v ./...
+	$(GOGET) -t -v ./redisai/...
 
 TLS_CERT ?= redis.crt
 TLS_KEY ?= redis.key

--- a/examples/redisai_tls_client/redisai_tls_client.go
+++ b/examples/redisai_tls_client/redisai_tls_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"io/ioutil"
 	"log"
+	"os"
 )
 
 var (
@@ -19,11 +20,26 @@ var (
 	password      = flag.String("password", "", "Redis password.")
 )
 
+func exists(filename string) (exists bool) {
+	exists = false
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) || info.IsDir() {
+		return
+	}
+	exists = true
+	return
+}
+
 /*
  * Example of how to establish an SSL connection from your app to the RedisAI Server
  */
 func main() {
 	flag.Parse()
+	// Quickly check if the files exist
+	if !exists(*tlsCertFile) || !exists(*tlsKeyFile) || !exists(*tlsCaCertFile) {
+		fmt.Println("Some of the required files does not exist. Leaving example...")
+		return
+	}
 
 	// Load client cert
 	cert, err := tls.LoadX509KeyPair(*tlsCertFile, *tlsKeyFile)

--- a/examples/redisai_tls_client/redisai_tls_client.go
+++ b/examples/redisai_tls_client/redisai_tls_client.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"github.com/RedisAI/redisai-go/redisai"
+	"github.com/gomodule/redigo/redis"
+	"io/ioutil"
+	"log"
+)
+
+var (
+	tlsCertFile   = flag.String("tls-cert-file", "redis.crt", "A a X.509 certificate to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted.")
+	tlsKeyFile    = flag.String("tls-key-file", "redis.key", "A a X.509 privat ekey to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted.")
+	tlsCaCertFile = flag.String("tls-ca-cert-file", "ca.crt", "A PEM encoded CA's certificate file.")
+	host          = flag.String("host", "127.0.0.1:6379", "Redis host.")
+	password      = flag.String("password", "", "Redis password.")
+)
+
+func main() {
+	flag.Parse()
+
+	// Load client cert
+	cert, err := tls.LoadX509KeyPair(*tlsCertFile, *tlsKeyFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Load CA cert
+	caCert, err := ioutil.ReadFile(*tlsCaCertFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}
+
+	// InsecureSkipVerify controls whether a client verifies the
+	// server's certificate chain and host name.
+	// If InsecureSkipVerify is true, TLS accepts any certificate
+	// presented by the server and any host name in that certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	// This should be used only for testing.
+	clientTLSConfig.InsecureSkipVerify = true
+
+	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
+		return redis.Dial("tcp", *host,
+			redis.DialPassword(*password),
+			redis.DialTLSConfig(clientTLSConfig),
+			redis.DialUseTLS(true),
+			redis.DialTLSSkipVerify(true),
+		)
+	}}
+
+	// create a connection from Pool
+	client := redisai.Connect("", pool)
+
+	// Set a tensor
+	// AI.TENSORSET foo FLOAT 2 2 VALUES 1.1 2.2 3.3 4.4
+	_ = client.TensorSet("foo", redisai.TypeFloat, []int{2, 2}, []float32{1.1, 2.2, 3.3, 4.4})
+
+	// Get a tensor content as a slice of values
+	// dt DataType, shape []int, data interface{}, err error
+	// AI.TENSORGET foo VALUES
+	_, _, fooTensorValues, err := client.TensorGetValues("foo")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(fooTensorValues)
+	//Output: [1.1 2.2 3.3 4.4]
+}

--- a/examples/redisai_tls_client/redisai_tls_client.go
+++ b/examples/redisai_tls_client/redisai_tls_client.go
@@ -19,6 +19,9 @@ var (
 	password      = flag.String("password", "", "Redis password.")
 )
 
+/*
+ * Example of how to establish an SSL connection from your app to the RedisAI Server
+ */
 func main() {
 	flag.Parse()
 

--- a/redisai/client_test.go
+++ b/redisai/client_test.go
@@ -22,6 +22,30 @@ func createPool() *redis.Pool {
 	return cpool
 }
 
+func getTLSdetails() (tlsready bool, tls_cert string, tls_key string, tls_cacert string) {
+	tlsready = false
+	value, exists := os.LookupEnv("TLS_CERT")
+	if exists && value != "" {
+		tls_cert = value
+	} else {
+		return
+	}
+	value, exists = os.LookupEnv("TLS_KEY")
+	if exists && value != "" {
+		tls_key = value
+	} else {
+		return
+	}
+	value, exists = os.LookupEnv("TLS_CACERT")
+	if exists && value != "" {
+		tls_cacert = value
+	} else {
+		return
+	}
+	tlsready = true
+	return
+}
+
 func createTestClient() *Client {
 	value, exists := os.LookupEnv("REDISAI_TEST_HOST")
 	host := "redis://localhost:6379"

--- a/redisai/example_client_test.go
+++ b/redisai/example_client_test.go
@@ -1,0 +1,30 @@
+package redisai_test
+
+import (
+	_ "github.com/RedisAI/redisai-go/redisai"
+	"os"
+)
+
+func getTLSdetails() (tlsready bool, tls_cert string, tls_key string, tls_cacert string) {
+	tlsready = false
+	value, exists := os.LookupEnv("TLS_CERT")
+	if exists && value != "" {
+		tls_cert = value
+	} else {
+		return
+	}
+	value, exists = os.LookupEnv("TLS_KEY")
+	if exists && value != "" {
+		tls_key = value
+	} else {
+		return
+	}
+	value, exists = os.LookupEnv("TLS_CACERT")
+	if exists && value != "" {
+		tls_cacert = value
+	} else {
+		return
+	}
+	tlsready = true
+	return
+}

--- a/redisai/example_client_test.go
+++ b/redisai/example_client_test.go
@@ -1,30 +1,134 @@
 package redisai_test
 
 import (
-	_ "github.com/RedisAI/redisai-go/redisai"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"github.com/RedisAI/redisai-go/redisai"
+	"github.com/gomodule/redigo/redis"
+	"io/ioutil"
+	"log"
 	"os"
 )
+
+func getConnectionDetails() (host string, password string) {
+	value, exists := os.LookupEnv("REDISAI_TEST_HOST")
+	host = "localhost:6379"
+	password = ""
+	valuePassword, existsPassword := os.LookupEnv("REDISAI_TEST_PASSWORD")
+	if exists && value != "" {
+		host = value
+	}
+	if existsPassword && valuePassword != "" {
+		password = valuePassword
+	}
+	return
+}
 
 func getTLSdetails() (tlsready bool, tls_cert string, tls_key string, tls_cacert string) {
 	tlsready = false
 	value, exists := os.LookupEnv("TLS_CERT")
 	if exists && value != "" {
+		info, err := os.Stat(value)
+		if os.IsNotExist(err) || info.IsDir() {
+			return
+		}
 		tls_cert = value
 	} else {
 		return
 	}
 	value, exists = os.LookupEnv("TLS_KEY")
 	if exists && value != "" {
+		info, err := os.Stat(value)
+		if os.IsNotExist(err) || info.IsDir() {
+			return
+		}
 		tls_key = value
 	} else {
 		return
 	}
 	value, exists = os.LookupEnv("TLS_CACERT")
 	if exists && value != "" {
+		info, err := os.Stat(value)
+		if os.IsNotExist(err) || info.IsDir() {
+			return
+		}
 		tls_cacert = value
 	} else {
 		return
 	}
 	tlsready = true
 	return
+}
+
+/*
+ * Example of how to establish an SSL connection from your app to the RedisAI Server
+ */
+func ExampleConnect_TLS() {
+	// Consider the following helper methods that provide us with the connection details (host and password)
+	// and the paths for:
+	//     tls_cert - A a X.509 certificate to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted
+	//     tls_key - A a X.509 private key to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted
+	//	   tls_cacert - A PEM encoded CA's certificate file
+	host, password := getConnectionDetails()
+	tlsready, tls_cert, tls_key, tls_cacert := getTLSdetails()
+
+	// Skip if we dont have all files to properly connect
+	if tlsready == false {
+		return
+	}
+
+	// Load client cert
+	cert, err := tls.LoadX509KeyPair(tls_cert, tls_key)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Load CA cert
+	caCert, err := ioutil.ReadFile(tls_cacert)
+	if err != nil {
+		log.Fatal(err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}
+
+	// InsecureSkipVerify controls whether a client verifies the
+	// server's certificate chain and host name.
+	// If InsecureSkipVerify is true, TLS accepts any certificate
+	// presented by the server and any host name in that certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	// This should be used only for testing.
+	clientTLSConfig.InsecureSkipVerify = true
+
+	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
+		return redis.Dial("tcp", host,
+			redis.DialPassword(password),
+			redis.DialTLSConfig(clientTLSConfig),
+			redis.DialUseTLS(true),
+			redis.DialTLSSkipVerify(true),
+		)
+	}}
+
+	// create a connection from Pool
+	client := redisai.Connect("", pool)
+
+	// Set a tensor
+	// AI.TENSORSET foo FLOAT 2 2 VALUES 1.1 2.2 3.3 4.4
+	_ = client.TensorSet("foo", redisai.TypeFloat, []int{2, 2}, []float32{1.1, 2.2, 3.3, 4.4})
+
+	// Get a tensor content as a slice of values
+	// dt DataType, shape []int, data interface{}, err error
+	// AI.TENSORGET foo VALUES
+	_, _, fooTensorValues, err := client.TensorGetValues("foo")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(fooTensorValues)
 }


### PR DESCRIPTION
includes an example ( that the users and quickly adust) on how to connect with tls support:
quick way of testing:
```
make examples
```

how can users test it quickly on their envs:

```
redisai-go/examples/redisai_tls_client$ ./redisai_tls_client -h
Usage of ./redisai_tls_client:
  -host string
        Redis host. (default "127.0.0.1:6379")
  -password string
        Redis password.
  -tls-ca-cert-file string
        A PEM encoded CA's certificate file. (default "ca.crt")
  -tls-cert-file string
        A a X.509 certificate to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted. (default "redis.crt")
  -tls-key-file string
        A a X.509 privat ekey to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted. (default "redis.key")

```