### PR TITLE
[add] extended godoc with 10 more examples 

### DIFF
--- a/redisai/commands_test.go
+++ b/redisai/commands_test.go
@@ -978,3 +978,40 @@ func TestCommand_DagRunRO(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_ModelRun(t *testing.T) {
+	type fields struct {
+		Pool                  *redis.Pool
+		PipelineActive        bool
+		PipelineAutoFlushSize uint32
+		PipelinePos           uint32
+		ActiveConn            redis.Conn
+	}
+	type args struct {
+		name              string
+		inputTensorNames  []string
+		outputTensorNames []string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				Pool:                  tt.fields.Pool,
+				PipelineActive:        tt.fields.PipelineActive,
+				PipelineAutoFlushSize: tt.fields.PipelineAutoFlushSize,
+				PipelinePos:           tt.fields.PipelinePos,
+				ActiveConn:            tt.fields.ActiveConn,
+			}
+			if err := c.ModelRun(tt.args.name, tt.args.inputTensorNames, tt.args.outputTensorNames); (err != nil) != tt.wantErr {
+				t.Errorf("ModelRun() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/redisai/example_commands_test.go
+++ b/redisai/example_commands_test.go
@@ -1,0 +1,220 @@
+package redisai_test
+
+import (
+	"fmt"
+	"github.com/RedisAI/redisai-go/redisai"
+	"github.com/RedisAI/redisai-go/redisai/implementations"
+	"io/ioutil"
+)
+
+func ExampleClient_TensorSet() {
+	// Create a simple client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+
+	// Set a tensor
+	// AI.TENSORSET foo FLOAT 2 2 VALUES 1.1 2.2 3.3 4.4
+	err := client.TensorSet("foo", redisai.TypeFloat, []int{2, 2}, []float32{1.1, 2.2, 3.3, 4.4})
+
+	// print the error (should be <nil>)
+	fmt.Println(err)
+	// Output: <nil>
+}
+
+func ExampleClient_TensorSetFromTensor() {
+	// Create a simple client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+
+	// Build a tensor
+	tensor := implementations.NewAiTensor()
+	tensor.SetShape([]int{2, 2})
+	tensor.SetData([]float32{1.1, 2.2, 3.3, 4.4})
+
+	// Set a tensor
+	// AI.TENSORSET foo FLOAT 2 2 VALUES 1.1 2.2 3.3 4.4
+	err := client.TensorSetFromTensor("foo", tensor)
+
+	// print the error (should be <nil>)
+	fmt.Println(err)
+	// Output: <nil>
+}
+
+func ExampleClient_TensorGet() {
+	// Create a client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+
+	// Set a tensor
+	// AI.TENSORSET foo FLOAT 2 2 VALUES 1.1 2.2 3.3 4.4
+	_ = client.TensorSet("foo", redisai.TypeFloat, []int{2, 2}, []float32{1.1, 2.2, 3.3, 4.4})
+
+	// Get a tensor content as a slice of values
+	// AI.TENSORGET foo VALUES
+	fooTensorValues, err := client.TensorGet("foo", redisai.TensorContentTypeValues)
+
+	fmt.Println(fooTensorValues, err)
+	// Output: [FLOAT [2 2] [1.1 2.2 3.3 4.4]] <nil>
+}
+
+func ExampleClient_TensorGetToTensor() {
+	// Create a client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+
+	// Set a tensor
+	// AI.TENSORSET foo FLOAT 2 2 VALUES 1.1 2.2 3.3 4.4
+	_ = client.TensorSet("foo", redisai.TypeFloat, []int{2, 2}, []float32{1.1, 2.2, 3.3, 4.4})
+
+	// Get a tensor content as a slice of values
+	// AI.TENSORGET foo VALUES
+	// Allocate an empty tensor
+	fooTensor := implementations.NewAiTensor()
+	err := client.TensorGetToTensor("foo", redisai.TensorContentTypeValues, fooTensor)
+
+	// Print the tensor data
+	fmt.Println(fooTensor.Data(), err)
+	// Output: [1.1 2.2 3.3 4.4] <nil>
+}
+
+func ExampleClient_ModelSet() {
+	// Create a client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+	data, _ := ioutil.ReadFile("./../tests/test_data/creditcardfraud.pb")
+	err := client.ModelSet("financialNet", redisai.BackendTF, redisai.DeviceCPU, data, []string{"transaction", "reference"}, []string{"output"})
+
+	// Print the error, which should be <nil> in case of sucessfull modelset
+	fmt.Println(err)
+	// Output: <nil>
+}
+
+func ExampleClient_ModelGet() {
+	// Create a client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+	data, _ := ioutil.ReadFile("./../tests/test_data/creditcardfraud.pb")
+	err := client.ModelSet("financialNet", redisai.BackendTF, redisai.DeviceCPU, data, []string{"transaction", "reference"}, []string{"output"})
+
+	// Print the error, which should be <nil> in case of sucessfull modelset
+	fmt.Println(err)
+
+	/////////////////////////////////////////////////////////////
+	// The important part of ModelGet example starts here
+	reply, err := client.ModelGet("financialNet")
+	backend := reply[0]
+	device := reply[1]
+	// print the error (should be <nil>)
+	fmt.Println(err)
+	fmt.Println(backend,device)
+
+	// Output:
+	// <nil>
+	// <nil>
+	// TF CPU
+}
+
+func ExampleClient_ModelSetFromModel() {
+	// Create a client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+
+	// Create a model
+	model := implementations.NewModel("TF", "CPU")
+	model.SetInputs([]string{"transaction", "reference"})
+	model.SetOutputs([]string{"output"})
+	model.SetBlobFromFile("./../tests/test_data/creditcardfraud.pb")
+
+	err := client.ModelSetFromModel("financialNet", model)
+
+	// Print the error, which should be <nil> in case of successful modelset
+	fmt.Println(err)
+	// Output: <nil>
+}
+
+func ExampleClient_ModelGetToModel() {
+	// Create a client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+
+	// Create a model
+	model := implementations.NewModel("TF", "CPU")
+	model.SetInputs([]string{"transaction", "reference"})
+	model.SetOutputs([]string{"output"})
+
+	// Read the model from file
+	model.SetBlobFromFile("./../tests/test_data/creditcardfraud.pb")
+
+	// Set the model to RedisAI so that we can afterwards test the modelget
+	err := client.ModelSetFromModel("financialNet", model)
+	// print the error (should be <nil>)
+	fmt.Println(err)
+
+	/////////////////////////////////////////////////////////////
+	// The important part of ModelGetToModel example starts here
+	// Create an empty load to store the model from RedisAI
+	model1 := implementations.NewEmptyModel()
+	err = client.ModelGetToModel("financialNet", model1)
+	// print the error (should be <nil>)
+	fmt.Println(err)
+
+	// print the backend and device info of the model
+	fmt.Println(model1.Backend(), model1.Device())
+
+	// Output:
+	// <nil>
+	// <nil>
+	// TF CPU
+}
+
+func ExampleClient_ModelRun() {
+	// Create a client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+
+	// read the model from file
+	data, err := ioutil.ReadFile("./../tests/test_data/graph.pb")
+
+	// set the model to RedisAI
+	err = client.ModelSet("example-model", redisai.BackendTF, redisai.DeviceCPU, data, []string{"a", "b"}, []string{"mul"})
+	// print the error (should be <nil>)
+	fmt.Println(err)
+
+	// set the input tensors
+	err = client.TensorSet("a", redisai.TypeFloat32, []int{1}, []float32{1.1})
+	err = client.TensorSet("b", redisai.TypeFloat32, []int{1}, []float32{4.4})
+
+	// run the model
+	err = client.ModelRun("example-model", []string{"a", "b"}, []string{"mul"})
+	// print the error (should be <nil>)
+	fmt.Println(err)
+
+	// Output:
+	// <nil>
+	// <nil>
+}
+
+
+func ExampleClient_Info() {
+	// Create a client.
+	client := redisai.Connect("redis://localhost:6379", nil)
+
+	// read the model from file
+	data, err := ioutil.ReadFile("./../tests/test_data/graph.pb")
+
+	// set the model to RedisAI
+	err = client.ModelSet("example-info", redisai.BackendTF, redisai.DeviceCPU, data, []string{"a", "b"}, []string{"mul"})
+	// print the error (should be <nil>)
+	fmt.Println(err)
+
+	// set the input tensors
+	err = client.TensorSet("a", redisai.TypeFloat32, []int{1}, []float32{1.1})
+	err = client.TensorSet("b", redisai.TypeFloat32, []int{1}, []float32{4.4})
+
+	// run the model
+	err = client.ModelRun("example-info", []string{"a", "b"}, []string{"mul"})
+	// print the error (should be <nil>)
+	fmt.Println(err)
+
+	// get the model run info
+	info, err := client.Info("example-info")
+
+	// one model runs
+	fmt.Println(fmt.Sprintf("Total runs: %s", info["calls"]))
+
+	// Output:
+	// <nil>
+	// <nil>
+	// Total runs: 1
+}

--- a/redisai/implementations/AIModel.go
+++ b/redisai/implementations/AIModel.go
@@ -2,7 +2,7 @@ package implementations
 
 import "io/ioutil"
 
-type AiModel struct {
+type AIModel struct {
 	backend string
 	device  string
 	blob    []byte
@@ -10,55 +10,55 @@ type AiModel struct {
 	outputs []string
 }
 
-func (m *AiModel) Outputs() []string {
+func (m *AIModel) Outputs() []string {
 	return m.outputs
 }
 
-func (m *AiModel) SetOutputs(outputs []string) {
+func (m *AIModel) SetOutputs(outputs []string) {
 	m.outputs = outputs
 }
 
-func (m *AiModel) Inputs() []string {
+func (m *AIModel) Inputs() []string {
 	return m.inputs
 }
 
-func (m *AiModel) SetInputs(inputs []string) {
+func (m *AIModel) SetInputs(inputs []string) {
 	m.inputs = inputs
 }
 
-func (m *AiModel) Blob() []byte {
+func (m *AIModel) Blob() []byte {
 	return m.blob
 }
 
-func (m *AiModel) SetBlob(blob []byte) {
+func (m *AIModel) SetBlob(blob []byte) {
 	m.blob = blob
 }
 
-func (m *AiModel) Device() string {
+func (m *AIModel) Device() string {
 	return m.device
 }
 
-func (m *AiModel) SetDevice(device string) {
+func (m *AIModel) SetDevice(device string) {
 	m.device = device
 }
 
-func (m *AiModel) Backend() string {
+func (m *AIModel) Backend() string {
 	return m.backend
 }
 
-func (m *AiModel) SetBackend(backend string) {
+func (m *AIModel) SetBackend(backend string) {
 	m.backend = backend
 }
 
-func NewModel(backend string, device string) *AiModel {
-	return &AiModel{backend: backend, device: device}
+func NewModel(backend string, device string) *AIModel {
+	return &AIModel{backend: backend, device: device}
 }
 
-func NewEmptyModel() *AiModel {
-	return &AiModel{}
+func NewEmptyModel() *AIModel {
+	return &AIModel{}
 }
 
-func (m *AiModel) SetBlobFromFile(path string) (err error) {
+func (m *AIModel) SetBlobFromFile(path string) (err error) {
 	var data []byte
 	data, err = ioutil.ReadFile(path)
 	if err != nil {

--- a/redisai/implementations/AITensor.go
+++ b/redisai/implementations/AITensor.go
@@ -4,26 +4,26 @@ import "reflect"
 
 // TensorInterface is an interface that represents the skeleton of a tensor ( n-dimensional array of numerical data )
 // needed to map it to a RedisAI Model with the proper operations
-type AiTensor struct {
+type AITensor struct {
 	// the size - in each dimension - of the tensor.
 	shape []int
 
 	data interface{}
 }
 
-func (t *AiTensor) Dtype() reflect.Type {
+func (t *AITensor) Dtype() reflect.Type {
 	return reflect.TypeOf(t.data)
 }
 
-func NewAiTensor() *AiTensor {
-	return &AiTensor{}
+func NewAiTensor() *AITensor {
+	return &AITensor{}
 }
 
-func (t *AiTensor) NumDims() int {
+func (t *AITensor) NumDims() int {
 	return len(t.Shape())
 }
 
-func (t *AiTensor) Len() int {
+func (t *AITensor) Len() int {
 	result := 0
 	for _, v := range t.shape {
 		result += v
@@ -31,28 +31,28 @@ func (t *AiTensor) Len() int {
 	return result
 }
 
-func (m *AiTensor) Shape() []int {
+func (m *AITensor) Shape() []int {
 	return m.shape
 }
 
-func (m *AiTensor) SetShape(shape []int) {
+func (m *AITensor) SetShape(shape []int) {
 	m.shape = shape
 }
 
-func NewAiTensorWithShape(shape []int) *AiTensor {
-	return &AiTensor{shape: shape}
+func NewAiTensorWithShape(shape []int) *AITensor {
+	return &AITensor{shape: shape}
 }
 
-func NewAiTensorWithData(typestr string, shape []int, data interface{}) *AiTensor {
+func NewAiTensorWithData(typestr string, shape []int, data interface{}) *AITensor {
 	tensor := NewAiTensorWithShape(shape)
 	tensor.SetData(data)
 	return tensor
 }
 
-func (m *AiTensor) SetData(data interface{}) {
+func (m *AITensor) SetData(data interface{}) {
 	m.data = data
 }
 
-func (m *AiTensor) Data() interface{} {
+func (m *AITensor) Data() interface{} {
 	return m.data
 }


### PR DESCRIPTION
@gkorland as per our conversation this PR extends the documentation with 10 more examples for Model and Tensor related commands. 
Added examples:
    Client.Info
    Client.ModelGet
    Client.ModelGetToModel
    Client.ModelRun
    Client.ModelSet
    Client.ModelSetFromModel
    Client.TensorGet
    Client.TensorGetToTensor
    Client.TensorSet
    Client.TensorSetFromTensor