### PR TITLE
Support for BACKENDSPATH <path> on AI.CONFIG

### DIFF
--- a/redisai/commands.go
+++ b/redisai/commands.go
@@ -250,3 +250,8 @@ func AddDagRunArgs(loadKeys []string, persistKeys []string, commandArgs redis.Ar
 	}
 	return args
 }
+
+// Sets the default backends path
+func (c *Client) SetBackendPath(path string) (string, error) {
+	return redis.String(c.DoOrSend("AI.CONFIG", redis.Args{"BACKENDSPATH", path}, nil))
+}

--- a/redisai/commands.go
+++ b/redisai/commands.go
@@ -252,6 +252,6 @@ func AddDagRunArgs(loadKeys []string, persistKeys []string, commandArgs redis.Ar
 }
 
 // Sets the default backends path
-func (c *Client) SetBackendPath(path string) (string, error) {
+func (c *Client) SetBackendsPath(path string) (string, error) {
 	return redis.String(c.DoOrSend("AI.CONFIG", redis.Args{"BACKENDSPATH", path}, nil))
 }

--- a/redisai/commands_test.go
+++ b/redisai/commands_test.go
@@ -1041,3 +1041,10 @@ func TestClient_ModelRun(t *testing.T) {
 		})
 	}
 }
+
+func TestCommand_SetBackendPath(t *testing.T) {
+	c := createTestClient()
+	ret, err := c.SetBackendPath("/usr/lib/redis/modules/backends/")
+	assert.Nil(t, err)
+	assert.Equal(t, "OK", ret)
+}

--- a/redisai/commands_test.go
+++ b/redisai/commands_test.go
@@ -1042,9 +1042,9 @@ func TestClient_ModelRun(t *testing.T) {
 	}
 }
 
-func TestCommand_SetBackendPath(t *testing.T) {
+func TestCommand_SetBackendsPath(t *testing.T) {
 	c := createTestClient()
-	ret, err := c.SetBackendPath("/usr/lib/redis/modules/backends/")
+	ret, err := c.SetBackendsPath("/usr/lib/redis/modules/backends/")
 	assert.Nil(t, err)
 	assert.Equal(t, "OK", ret)
 }


### PR DESCRIPTION
further reference: https://oss.redislabs.com/redisai/configuration/#backendspath
fixes #26